### PR TITLE
Fix stale report upload and migrate from pyright to ty

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
       run: uv run ruff format --check
 
     - name: Type checking
-      run: uv run pyright
+      run: uv run ty check
 
     - name: Unit tests
       run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quartoogle"
-version = "0.1.3"
+version = "0.1.4"
 description = "Compile quarto docs directly to google drive"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
     "great-tables>=0.19.0",
     "matplotlib>=3.10.7",
     "pandas>=2.3.3",
-    "pyright>=1.1.406",
+    "ty>=0.0.1a7",
     "pytest>=8.4.2",
     "pytest-mock>=3.14.0",
     "ruff>=0.14.0",
@@ -42,7 +42,7 @@ packages = ["src/quartoogle",]
 [tool.pytest.ini_options]
 testpaths = ["tests",]
 
-[tool.pyright]
+[tool.ty.src]
 include = ["src", "tests"]
 
 [tool.ruff]
@@ -58,7 +58,7 @@ select = [
   "I", # flake8-import-order
   "TID", # flake8-tidy-imports
   "D", # google-style docstrings,
-  "ANN", # require pyright type annotations
+  "ANN", # require type annotations
 ]
 ignore = [
   "ANN002", # Missing type annotation for *args

--- a/src/quartoogle/quarto.py
+++ b/src/quartoogle/quarto.py
@@ -23,12 +23,18 @@ def compile_quarto(source_path: Path, output_format: str = "pdf") -> Path:
     """
     logger.debug(f"Rendering {source_path} to {output_format}")
 
+    # Determine output path (quarto creates output file next to source)
+    output_path = source_path.with_suffix(f".{output_format}")
+
+    # Delete any existing output file to prevent uploading stale content
+    # if the current compilation fails (see GitHub issue #42)
+    if output_path.exists():
+        logger.debug(f"Removing existing output file: {output_path}")
+        output_path.unlink()
+
     # Use quiet mode unless logging level is DEBUG
     quiet = logger.getEffectiveLevel() > logging.DEBUG
     render(str(source_path), output_format=output_format, quiet=quiet)
-
-    # Determine output path (quarto creates output file next to source)
-    output_path = source_path.with_suffix(f".{output_format}")
 
     if not output_path.exists():
         raise RuntimeError(f"Expected output file not found: {output_path}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from click.testing import CliRunner
+from pytest_mock import MockerFixture
 
 from quartoogle.cli import main
 
@@ -35,18 +36,24 @@ def test_cli_missing_output_arg() -> None:
     assert result.exit_code == 2
 
 
-def test_cli_with_to_option(tmp_path: Path) -> None:
+def test_cli_with_to_option(tmp_path: Path, mocker: MockerFixture) -> None:
     """Test that CLI accepts --to option for format."""
     # Create a .qmd file
     test_file = tmp_path / "test.qmd"
     test_file.write_text("# Test")
 
+    # Mock publish to avoid real quarto/Google calls
+    mock_publish = mocker.patch("quartoogle.cli.publish")
+    mock_publish.return_value = ("file123", "https://example.com/file123")
+
     runner = CliRunner()
     result = runner.invoke(main, [str(test_file), "--folder-id", "1a2b3c4d5e6f7g8h9i0j", "--to", "html"])
 
-    # Should fail (no real quarto/google creds) but should accept the --to option
-    # The error should not be about the --to option
-    assert "--to" not in result.output or result.exit_code != 2
+    assert result.exit_code == 0
+    # Verify publish was called with the html format
+    mock_publish.assert_called_once()
+    call_args = mock_publish.call_args
+    assert call_args[0][2] == "html"  # output_format argument
 
 
 def test_cli_invalid_file_extension(tmp_path: Path) -> None:

--- a/tests/test_quarto.py
+++ b/tests/test_quarto.py
@@ -42,16 +42,65 @@ def test_compile_to_docx_output_not_found(mocker: MockerFixture) -> None:
     assert "not found" in str(exc_info.value).lower()
 
 
+def test_stale_output_file_deleted_before_compilation(tmp_path: Path, mocker: MockerFixture) -> None:
+    """Test that stale output files are deleted before compilation.
+
+    This prevents uploading an old report if the current compilation fails.
+    Reproduces GitHub issue #42.
+    """
+    source = tmp_path / "test.qmd"
+    source.write_text("# Test")
+    pdf = tmp_path / "test.pdf"
+    # Create an old/stale PDF file
+    pdf.write_bytes(b"stale pdf content")
+    assert pdf.exists()
+
+    mock_render = mocker.patch("quartoogle.quarto.render")
+    # Simulate render failing silently (doesn't raise, but doesn't create file)
+    mock_render.return_value = None
+
+    with pytest.raises(RuntimeError) as exc_info:
+        compile_quarto(source)
+
+    # The error should indicate no output file, not return the stale file
+    assert "not found" in str(exc_info.value).lower()
+    # The stale file should have been deleted
+    assert not pdf.exists()
+
+
+def test_stale_output_file_replaced_on_success(tmp_path: Path, mocker: MockerFixture) -> None:
+    """Test that stale output files are replaced when compilation succeeds."""
+    source = tmp_path / "test.qmd"
+    source.write_text("# Test")
+    pdf = tmp_path / "test.pdf"
+    # Create an old/stale PDF file
+    pdf.write_bytes(b"stale pdf content")
+
+    def mock_render_side_effect(*args, **kwargs) -> None:
+        # Simulate successful render by creating new file content
+        pdf.write_bytes(b"new pdf content")
+
+    mock_render = mocker.patch("quartoogle.quarto.render")
+    mock_render.side_effect = mock_render_side_effect
+
+    result = compile_quarto(source)
+
+    assert result == pdf
+    assert result.exists()
+    assert result.read_bytes() == b"new pdf content"
+
+
 def test_compile_to_docx_success(tmp_path: Path, mocker: MockerFixture) -> None:
     """Test successful compilation to PDF (default)."""
     source = tmp_path / "test.qmd"
     source.write_text("# Test")
     pdf = tmp_path / "test.pdf"
-    pdf.write_bytes(b"fake pdf")
+
+    def mock_render_side_effect(*args, **kwargs) -> None:
+        pdf.write_bytes(b"fake pdf")
 
     mock_render = mocker.patch("quartoogle.quarto.render")
-    # Mock successful render
-    mock_render.return_value = None
+    mock_render.side_effect = mock_render_side_effect
 
     result = compile_quarto(source)
 
@@ -66,11 +115,12 @@ def test_compile_quarto_with_docx(tmp_path: Path, mocker: MockerFixture) -> None
     source = tmp_path / "test.qmd"
     source.write_text("# Test")
     docx = tmp_path / "test.docx"
-    docx.write_bytes(b"fake docx")
+
+    def mock_render_side_effect(*args, **kwargs) -> None:
+        docx.write_bytes(b"fake docx")
 
     mock_render = mocker.patch("quartoogle.quarto.render")
-    # Mock successful render
-    mock_render.return_value = None
+    mock_render.side_effect = mock_render_side_effect
 
     result = compile_quarto(source, "docx")
 
@@ -85,11 +135,12 @@ def test_compile_to_docx_backward_compatibility(tmp_path: Path, mocker: MockerFi
     source = tmp_path / "test.qmd"
     source.write_text("# Test")
     docx = tmp_path / "test.docx"
-    docx.write_bytes(b"fake docx")
+
+    def mock_render_side_effect(*args, **kwargs) -> None:
+        docx.write_bytes(b"fake docx")
 
     mock_render = mocker.patch("quartoogle.quarto.render")
-    # Mock successful render
-    mock_render.return_value = None
+    mock_render.side_effect = mock_render_side_effect
 
     result = compile_to_docx(source)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1355,15 +1355,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
 name = "notebook"
 version = "7.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1763,19 +1754,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyright"
-version = "1.1.406"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/16/6b4fbdd1fef59a0292cbb99f790b44983e390321eccbc5921b4d161da5d1/pyright-1.1.406.tar.gz", hash = "sha256:c4872bc58c9643dac09e8a2e74d472c62036910b3bd37a32813989ef7576ea2c", size = 4113151, upload-time = "2025-10-02T01:04:45.488Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/a2/e309afbb459f50507103793aaef85ca4348b66814c86bc73908bdeb66d12/pyright-1.1.406-py3-none-any.whl", hash = "sha256:1d81fb43c2407bf566e97e57abb01c811973fdb21b2df8df59f870f688bdca71", size = 5980982, upload-time = "2025-10-02T01:04:43.137Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1987,11 +1965,11 @@ dev = [
     { name = "great-tables" },
     { name = "matplotlib" },
     { name = "pandas" },
-    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "ruff" },
     { name = "tabulate" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -2011,11 +1989,11 @@ dev = [
     { name = "great-tables", specifier = ">=0.19.0" },
     { name = "matplotlib", specifier = ">=3.10.7" },
     { name = "pandas", specifier = ">=2.3.3" },
-    { name = "pyright", specifier = ">=1.1.406" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = ">=0.14.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
+    { name = "ty", specifier = ">=0.0.1a7" },
 ]
 
 [[package]]
@@ -2332,6 +2310,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/20/2ba8fd9493c89c41dfe9dbb73bc70a28b28028463bc0d2897ba8be36230a/ty-0.0.21.tar.gz", hash = "sha256:a4c2ba5d67d64df8fcdefd8b280ac1149d24a73dbda82fa953a0dff9d21400ed", size = 5297967, upload-time = "2026-03-06T01:57:13.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/70/edf38bb37517531681d1c37f5df64744e5ad02673c02eb48447eae4bea08/ty-0.0.21-py3-none-linux_armv6l.whl", hash = "sha256:7bdf2f572378de78e1f388d24691c89db51b7caf07cf90f2bfcc1d6b18b70a76", size = 10299222, upload-time = "2026-03-06T01:57:16.64Z" },
+    { url = "https://files.pythonhosted.org/packages/72/62/0047b0bd19afeefbc7286f20a5f78a2aa39f92b4d89853f0d7185ab89edc/ty-0.0.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7e9613994610431ab8625025bd2880dbcb77c5c9fabdd21134cda12d840a529d", size = 10130513, upload-time = "2026-03-06T01:57:29.93Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/20/0b93a9e91aaed23155780258cdfdb4726ef68b6985378ac069bc427291a0/ty-0.0.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:56d3b198b64dd0a19b2b66e257deaed2ecea568e722ae5352f3c6fb62027f89d", size = 9605425, upload-time = "2026-03-06T01:57:27.115Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fd/9945e2fa2996a1287b1e1d7ce050e97e1f420233b271e770934bfa0880a0/ty-0.0.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d23d2c34f7a77d974bb08f0860ef700addc8a683d81a0319f71c08f87506cfd0", size = 10108298, upload-time = "2026-03-06T01:57:35.429Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e7/4ec52fcb15f3200826c9f048472c062549a05b0d1ef0b51f32d527b513c4/ty-0.0.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56b01fd2519637a4ca88344f61c96225f540c98ff18bca321d4eaa7bb0f7aa2f", size = 10121556, upload-time = "2026-03-06T01:57:03.242Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/c0/ad457be2a8abea0f25549598bd098554540ced66229488daa0d558dad3c8/ty-0.0.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9de7e11c63c6afc40f3e9ba716374add171aee7fabc70b5146a510705c6d41b", size = 10603264, upload-time = "2026-03-06T01:56:52.134Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5b/2ecc7a2175243a4bcb72f5298ae41feabbb93b764bb0dc45722f3752c2c2/ty-0.0.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:62f7f5b235c4f7876db305c36997aea07b7af29b1a068f373d0e2547e25f32ff", size = 11196428, upload-time = "2026-03-06T01:57:32.94Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f5/aff507d6a901f328ef96a298032b0c11aaaf950a146ed7dd3b5bf2cd3acf/ty-0.0.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee8399f7c453a425291e6688efe430cfae7ab0ac4ffd50eba9f872bf878b54f6", size = 10866355, upload-time = "2026-03-06T01:56:57.831Z" },
+    { url = "https://files.pythonhosted.org/packages/be/30/822bbcb92d55b65989aa7ed06d9585f28ade9c9447369194ed4b0fb3b5b9/ty-0.0.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:210e7568c9f886c4d01308d751949ee714ad7ad9d7d928d2ba90d329dd880367", size = 10738177, upload-time = "2026-03-06T01:57:11.256Z" },
+    { url = "https://files.pythonhosted.org/packages/57/cc/46e7991b6469e93ac2c7e533a028983e402485580150ac864c56352a3a82/ty-0.0.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:53508e345b11569f78b21ba8e2b4e61df38a9754947fb3cd9f2ef574367338fb", size = 10079158, upload-time = "2026-03-06T01:57:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c2/0bbdadfbd008240f8f1a87dc877433cb3884436097926107ccf06e618199/ty-0.0.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:553e43571f4a35604c36cfd07d8b61a5eb7a714e3c67f8c4ff2cf674fefbaef9", size = 10150535, upload-time = "2026-03-06T01:57:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/2dbdb7b57b5362200ef0a39738ebd31331726328336def0143ac097ee59d/ty-0.0.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:666f6822e3b9200abfa7e95eb0ddd576460adb8d66b550c0ad2c70abc84a2048", size = 10319803, upload-time = "2026-03-06T01:57:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/72/84/70e52c0b7abc7c2086f9876ef454a73b161d3125315536d8d7e911c94ca4/ty-0.0.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a0854d008347ce4a5fb351af132f660a390ab2a1163444d075251d43e6f74b9b", size = 10826239, upload-time = "2026-03-06T01:57:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/8a/1f72480fd013bbc6cd1929002abbbcde9a0b08ead6a15154de9d7f7fa37e/ty-0.0.21-py3-none-win32.whl", hash = "sha256:bef3ab4c7b966bcc276a8ac6c11b63ba222d21355b48d471ea782c4104eee4e0", size = 9693196, upload-time = "2026-03-06T01:57:24.126Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f8/1104808b875c26c640e536945753a78562d606bef4e241d9dbf3d92477f6/ty-0.0.21-py3-none-win_amd64.whl", hash = "sha256:a709d576e5bea84b745d43058d8b9cd4f27f74a0b24acb4b0cbb7d3d41e0d050", size = 10668660, upload-time = "2026-03-06T01:56:55.06Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b8/25e0adc404bbf986977657b25318991f93097b49f8aea640d93c0b0db68e/ty-0.0.21-py3-none-win_arm64.whl", hash = "sha256:f72047996598ac20553fb7e21ba5741e3c82dee4e9eadf10d954551a5fe09391", size = 10104161, upload-time = "2026-03-06T01:57:06.072Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1947,7 +1947,7 @@ wheels = [
 
 [[package]]
 name = "quartoogle"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary
- Delete existing output file before compilation to prevent uploading stale content when current compilation fails (fixes #42)
- Add tests reproducing and verifying the fix for issue #42
- Migrate type checker from pyright to ty
- Update CLI tests to properly mock publish function to avoid hanging on real quarto/Google calls

## Test plan
- [x] All 24 unit tests pass
- [x] ruff check passes
- [x] ty check passes
- [x] New tests verify that stale output files are deleted before compilation

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)